### PR TITLE
Add message and schema builders

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,8 @@ let package = Package(
       name: "AsyncAPIBuilder",
       dependencies: [
         "AsyncAPIGenerator",
-        .product(name: "JSONSchema", package: "swift-json-schema")
+        .product(name: "JSONSchema", package: "swift-json-schema"),
+        .product(name: "JSONSchemaBuilder", package: "swift-json-schema")
       ]
     ),
     .testTarget(

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ let asyncAPI = AsyncAPI(
             "lightMeasured": .init(
                 name: "lightMeasured",
                 contentType: "application/json",
-                payload: LightMeasured.schema.schemaValue.value,
+                payload: LightMeasured.jsonSchema,
                 title: "Light measured",
                 summary: "Inform about environmental lighting conditions"
             )

--- a/Sources/AsyncAPIBuilder/ComponentBuilders.swift
+++ b/Sources/AsyncAPIBuilder/ComponentBuilders.swift
@@ -1,0 +1,208 @@
+import AsyncAPIGenerator
+import JSONSchema
+import JSONSchemaBuilder
+
+public struct ComponentsBuilder {
+  var schemas: [String: JSONValue] = [:]
+  var messages: [String: AsyncAPI.Message] = [:]
+
+  mutating func addSchema(_ schema: Schema) {
+    schemas[schema.key] = schema.finish()
+  }
+
+  mutating func addMessage(_ message: Message) {
+    messages[message.key] = message.finish()
+  }
+
+  func finish() -> AsyncAPI.Components? {
+    if schemas.isEmpty && messages.isEmpty { return nil }
+    return AsyncAPI.Components(
+      schemas: schemas.isEmpty ? nil : schemas,
+      messages: messages.isEmpty ? nil : messages
+    )
+  }
+}
+
+public struct Schema {
+  let key: String
+  private var value: JSONValue
+
+  public init(key: String, value: JSONValue = .object([:])) {
+    self.key = key
+    self.value = value
+  }
+
+  public init(key: String, @JSONSchemaBuilder _ build: () -> some JSONSchemaComponent) {
+    self.key = key
+    self.value = build().schemaValue.value
+  }
+
+  public func value(_ value: JSONValue) -> Self {
+    var copy = self
+    copy.value = value
+    return copy
+  }
+
+  public func value(@JSONSchemaBuilder _ build: () -> some JSONSchemaComponent) -> Self {
+    var copy = self
+    copy.value = build().schemaValue.value
+    return copy
+  }
+
+  func finish() -> JSONValue { value }
+}
+
+public extension Schema {
+  /// Create a schema component using a type conforming to ``Schemable``.
+  ///
+  /// - Parameters:
+  ///   - key: The components dictionary key.
+  ///   - type: The ``Schemable`` type describing the JSON Schema.
+  init<T: Schemable>(key: String, for type: T.Type) {
+    self.key = key
+    self.value = type.schema.schemaValue.value
+  }
+}
+
+public struct Message {
+  let key: String
+  private var name: String?
+  private var contentType: String?
+  private var headers: JSONValue?
+  private var payload: JSONValue?
+  private var correlationId: AsyncAPI.CorrelationId?
+  private var title: String?
+  private var summary: String?
+  private var description: String?
+  private var tags: [AsyncAPI.Tag]?
+  private var externalDocs: AsyncAPI.ExternalDoc?
+  private var bindings: JSONValue?
+  private var examples: [JSONValue]?
+
+  public init(key: String) { self.key = key }
+
+  public func name(_ value: String) -> Self {
+    var copy = self
+    copy.name = value
+    return copy
+  }
+
+  public func contentType(_ value: String) -> Self {
+    var copy = self
+    copy.contentType = value
+    return copy
+  }
+
+  public func headers(_ value: JSONValue) -> Self {
+    var copy = self
+    copy.headers = value
+    return copy
+  }
+
+  public func headers(@JSONSchemaBuilder _ build: () -> some JSONSchemaComponent) -> Self {
+    var copy = self
+    copy.headers = build().schemaValue.value
+    return copy
+  }
+
+  /// Apply a headers schema from a ``Schemable`` type.
+  public func headers<T: Schemable>(_ type: T.Type) -> Self {
+    headers(type.schema.schemaValue.value)
+  }
+
+  public func payload(_ value: JSONValue) -> Self {
+    var copy = self
+    copy.payload = value
+    return copy
+  }
+
+  public func payload(@JSONSchemaBuilder _ build: () -> some JSONSchemaComponent) -> Self {
+    var copy = self
+    copy.payload = build().schemaValue.value
+    return copy
+  }
+
+  /// Apply a payload schema from a ``Schemable`` type.
+  public func payload<T: Schemable>(_ type: T.Type) -> Self {
+    payload(type.schema.schemaValue.value)
+  }
+
+  public func correlationId(_ value: AsyncAPI.CorrelationId) -> Self {
+    var copy = self
+    copy.correlationId = value
+    return copy
+  }
+
+  public func title(_ value: String) -> Self {
+    var copy = self
+    copy.title = value
+    return copy
+  }
+
+  public func summary(_ value: String) -> Self {
+    var copy = self
+    copy.summary = value
+    return copy
+  }
+
+  public func description(_ value: String) -> Self {
+    var copy = self
+    copy.description = value
+    return copy
+  }
+
+  public func tags(_ value: [AsyncAPI.Tag]) -> Self {
+    var copy = self
+    copy.tags = value
+    return copy
+  }
+
+  public func externalDocs(_ value: AsyncAPI.ExternalDoc) -> Self {
+    var copy = self
+    copy.externalDocs = value
+    return copy
+  }
+
+  public func bindings(_ value: JSONValue) -> Self {
+    var copy = self
+    copy.bindings = value
+    return copy
+  }
+
+  public func examples(_ value: [JSONValue]) -> Self {
+    var copy = self
+    copy.examples = value
+    return copy
+  }
+
+  func finish() -> AsyncAPI.Message {
+    AsyncAPI.Message(
+      name: name,
+      contentType: contentType,
+      headers: headers,
+      payload: payload,
+      correlationId: correlationId,
+      title: title,
+      summary: summary,
+      description: description,
+      tags: tags,
+      externalDocs: externalDocs,
+      bindings: bindings,
+      examples: examples
+    )
+  }
+}
+
+public extension SchemaValue {
+  var jsonValue: JSONValue {
+    switch self {
+    case .boolean(let bool): return .boolean(bool)
+    case .object(let dict): return .object(dict)
+    }
+  }
+}
+
+public extension Schemable {
+  /// The generated JSON Schema for this type as a ``JSONValue``.
+  static var jsonSchema: JSONValue { schema.schemaValue.value }
+}

--- a/Sources/AsyncAPIBuilder/TransportBindings.swift
+++ b/Sources/AsyncAPIBuilder/TransportBindings.swift
@@ -75,7 +75,8 @@ public func expandOperations(
 ) -> [AsyncAPI.Operation] {
   guard let operations = document.operations else { return [] }
   var result: [AsyncAPI.Operation] = []
-  for op in operations.values {
+  for key in operations.keys.sorted() {
+    let op = operations[key]!
     switch op.channel {
     case .reference(let ref):
       if ref == "#/channels/\(channel.address ?? "")" { result.append(op) }

--- a/Tests/AsyncAPIBuilderTests/MessageSchemaBuilderTests.swift
+++ b/Tests/AsyncAPIBuilderTests/MessageSchemaBuilderTests.swift
@@ -1,0 +1,47 @@
+import AsyncAPIBuilder
+import AsyncAPIGenerator
+import JSONSchema
+import JSONSchemaBuilder
+import Testing
+
+@Schemable
+struct ChatPayload {
+  let text: String
+}
+
+struct MessageSchemaBuilderTests {
+  @Test
+  func buildComponents() {
+    let doc = AsyncAPIDocument {
+      Info(title: "Chat", version: "1.0")
+      Schema(key: "ChatPayload", for: ChatPayload.self)
+      Message(key: "chatMessage")
+        .name("chatMessage")
+        .payload(ChatPayload.self)
+        .summary("A chat message")
+    }
+
+    let schema = doc.asyncapi.components?.schemas?["ChatPayload"]
+    let message = doc.asyncapi.components?.messages?["chatMessage"]
+
+    #expect(schema != nil)
+    #expect(message?.name == "chatMessage")
+    #expect(message?.summary == "A chat message")
+  }
+
+  @Test
+  func schemableConvenience() {
+    let doc = AsyncAPIDocument {
+      Info(title: "Chat", version: "1.0")
+      Schema(key: "ChatPayload", for: ChatPayload.self)
+      Message(key: "convenient")
+        .payload(ChatPayload.self)
+    }
+
+    let schema = doc.asyncapi.components?.schemas?["ChatPayload"]
+    let message = doc.asyncapi.components?.messages?["convenient"]
+
+    #expect(schema != nil)
+    #expect(message?.payload != nil)
+  }
+}

--- a/Tests/AsyncAPIBuilderTests/OperationMessageBuilderTests.swift
+++ b/Tests/AsyncAPIBuilderTests/OperationMessageBuilderTests.swift
@@ -1,0 +1,31 @@
+import AsyncAPIBuilder
+import AsyncAPIGenerator
+import JSONSchemaBuilder
+import Testing
+
+@Schemable
+struct PingPayload {
+  let msg: String
+}
+
+struct OperationMessageBuilderTests {
+  @Test
+  func operationWithMessageBuilder() {
+    let doc = AsyncAPIDocument {
+      Info(title: "Test", version: "1.0")
+      Operation(key: "ping", action: .send)
+        .channel(AsyncAPI.Channel(address: "ping"))
+        .messages([Message(key: "pingMsg")
+          .payload(PingPayload.self)
+        ])
+    }
+
+    let op = doc.asyncapi.operations?["ping"]
+    var payloadExists = false
+    if let first = op?.messages?.first, case .value(let value) = first {
+      payloadExists = value.payload != nil
+    }
+    #expect(payloadExists)
+    #expect(doc.asyncapi.components?.messages?["pingMsg"] == nil)
+  }
+}

--- a/Tests/AsyncAPIGeneratorTests/AsyncAPIGeneratorTests.swift
+++ b/Tests/AsyncAPIGeneratorTests/AsyncAPIGeneratorTests.swift
@@ -1,4 +1,5 @@
 import AsyncAPIGenerator
+import AsyncAPIBuilder
 import Foundation
 import InlineSnapshotTesting
 import JSONSchema
@@ -104,19 +105,19 @@ struct MessageSchemaTests {
           "lightMeasured": .init(
             name: "lightMeasured",
             contentType: "application/json",
-            payload: LightMeasured.schema.schemaValue.value,
+            payload: LightMeasured.jsonSchema,
             title: "Light measured",
             summary: "Inform about environmental lighting conditions"
           ),
           "turnOnOff": .init(
             name: "turnOnOff",
-            payload: TurnOnOff.schema.schemaValue.value,
+            payload: TurnOnOff.jsonSchema,
             title: "Turn on/off",
             summary: "Command to turn the light on or off"
           ),
           "dimLight": .init(
             name: "dimLight",
-            payload: DimLight.schema.schemaValue.value,
+            payload: DimLight.jsonSchema,
             title: "Dim light",
             summary: "Command to dim the lights"
           ),


### PR DESCRIPTION
## Summary
- add Schemable helpers for building schemas and messages
- keep operation binding order stable
- document Schemable helpers
- update README example
- add additional tests for new helpers

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_6858acf89b2883318efa414851ee5eb8