### PR TITLE
Add Channel modifiers and parameter builder

### DIFF
--- a/Sources/AsyncAPIBuilder/AsyncAPIDSL.swift
+++ b/Sources/AsyncAPIBuilder/AsyncAPIDSL.swift
@@ -258,6 +258,15 @@ public struct Channel {
   let key: String
   private let address: String
   let operations: [Operation]
+  private var title: String?
+  private var summary: String?
+  private var description: String?
+  private var servers: [ReferenceOr<AsyncAPI.Server>]?
+  private var tags: [AsyncAPI.Tag]?
+  private var externalDocs: AsyncAPI.ExternalDoc?
+  private var bindings: JSONValue?
+  private var messages: [String: ReferenceOr<AsyncAPI.Message>]?
+  private var parameters: [String: ReferenceOr<AsyncAPI.Parameter>]?
 
   public init(key: String, address: String) {
     self.key = key
@@ -275,9 +284,102 @@ public struct Channel {
     self.operations = operations()
   }
 
+  public func title(_ title: String) -> Self {
+    var copy = self
+    copy.title = title
+    return copy
+  }
+
+  public func summary(_ summary: String) -> Self {
+    var copy = self
+    copy.summary = summary
+    return copy
+  }
+
+  public func description(_ description: String) -> Self {
+    var copy = self
+    copy.description = description
+    return copy
+  }
+
+  public func servers(_ servers: [AsyncAPI.Server]) -> Self {
+    var copy = self
+    copy.servers = servers.map { .value($0) }
+    return copy
+  }
+
+  public func servers(refs: [String]) -> Self {
+    var copy = self
+    copy.servers = refs.map { .reference($0) }
+    return copy
+  }
+
+  public func tags(_ tags: [AsyncAPI.Tag]) -> Self {
+    var copy = self
+    copy.tags = tags
+    return copy
+  }
+
+  public func externalDocs(_ externalDocs: AsyncAPI.ExternalDoc) -> Self {
+    var copy = self
+    copy.externalDocs = externalDocs
+    return copy
+  }
+
+  public func bindings(_ bindings: JSONValue) -> Self {
+    var copy = self
+    copy.bindings = bindings
+    return copy
+  }
+
+  public func messages(_ messages: [String: AsyncAPI.Message]) -> Self {
+    var copy = self
+    copy.messages = messages.mapValues { .value($0) }
+    return copy
+  }
+
+  public func messages(_ messages: [Message]) -> Self {
+    var copy = self
+    copy.messages = Dictionary(uniqueKeysWithValues: messages.map { ($0.key, .value($0.finish())) })
+    return copy
+  }
+
+  public func messages(refs: [String: String]) -> Self {
+    var copy = self
+    copy.messages = refs.mapValues { .reference($0) }
+    return copy
+  }
+
+  public func parameters(_ parameters: [String: AsyncAPI.Parameter]) -> Self {
+    var copy = self
+    copy.parameters = parameters.mapValues { .value($0) }
+    return copy
+  }
+
+  public func parameters(_ parameters: [String: Parameter]) -> Self {
+    var copy = self
+    copy.parameters = parameters.mapValues { .value($0.finish()) }
+    return copy
+  }
+
+  public func parameters(refs: [String: String]) -> Self {
+    var copy = self
+    copy.parameters = refs.mapValues { .reference($0) }
+    return copy
+  }
+
   public func finish() -> AsyncAPI.Channel {
     AsyncAPI.Channel(
-      address: address
+      address: address,
+      title: title,
+      summary: summary,
+      description: description,
+      servers: servers,
+      tags: tags,
+      externalDocs: externalDocs,
+      bindings: bindings,
+      messages: messages,
+      parameters: parameters
     )
   }
 }
@@ -407,6 +509,50 @@ public struct Operation {
       tags: tags,
       externalDocs: externalDocs,
       bindings: bindings
+    )
+  }
+}
+
+public struct Parameter {
+  private var description: String?
+  private var schema: JSONValue?
+  private var location: String?
+
+  public init() {}
+
+  public func description(_ description: String) -> Self {
+    var copy = self
+    copy.description = description
+    return copy
+  }
+
+  public func schema(_ schema: JSONValue) -> Self {
+    var copy = self
+    copy.schema = schema
+    return copy
+  }
+
+  public func schema(@JSONSchemaBuilder _ build: () -> some JSONSchemaComponent) -> Self {
+    var copy = self
+    copy.schema = build().schemaValue.value
+    return copy
+  }
+
+  public func schema<T: Schemable>(_ type: T.Type) -> Self {
+    schema(type.schema.schemaValue.value)
+  }
+
+  public func location(_ location: String) -> Self {
+    var copy = self
+    copy.location = location
+    return copy
+  }
+
+  func finish() -> AsyncAPI.Parameter {
+    AsyncAPI.Parameter(
+      description: description,
+      schema: schema,
+      location: location
     )
   }
 }

--- a/Tests/AsyncAPIBuilderTests/AsyncAPIBuilderTests.swift
+++ b/Tests/AsyncAPIBuilderTests/AsyncAPIBuilderTests.swift
@@ -117,4 +117,45 @@ struct AsyncAPIBuilderTests {
     #expect(retrieved?.info.title == "Test Service")
     #expect(retrieved?.info.version == "1.0.0")
   }
+
+  @Test
+  func channelModifiers() {
+    let doc = AsyncAPIDocument {
+      Info(title: "Test", version: "1.0")
+
+      Channel(key: "c1", address: "addr")
+        .title("Title")
+        .summary("Sum")
+        .description("Desc")
+        .servers(refs: ["#/servers/s1"])
+        .tags([AsyncAPI.Tag(name: "tag")])
+        .externalDocs(AsyncAPI.ExternalDoc(url: "https://example.com"))
+        .bindings(["kafka": ["clientId": .string("id")]])
+        .messages(refs: ["m1": "#/components/messages/m1"])
+        .parameters(refs: ["id": "#/components/parameters/id"])
+    }
+
+    let channel = doc.asyncapi.channels?["c1"]
+    #expect(channel?.title == "Title")
+    #expect(channel?.summary == "Sum")
+    #expect(channel?.description == "Desc")
+    var serverRef = false
+    if let first = channel?.servers?.first, case .reference(let ref) = first {
+      serverRef = ref == "#/servers/s1"
+    }
+    #expect(serverRef)
+    #expect(channel?.tags?.first?.name == "tag")
+    #expect(channel?.externalDocs?.url == "https://example.com")
+    #expect(channel?.bindings != nil)
+    var msgRef = false
+    if let m = channel?.messages?["m1"], case .reference(let ref) = m {
+      msgRef = ref == "#/components/messages/m1"
+    }
+    #expect(msgRef)
+    var paramRef = false
+    if let p = channel?.parameters?["id"], case .reference(let ref) = p {
+      paramRef = ref == "#/components/parameters/id"
+    }
+    #expect(paramRef)
+  }
 }


### PR DESCRIPTION
## Summary
- add modifier methods for `Channel` to mirror `AsyncAPI.Channel`
- support messages and parameters as sub-builders or references
- introduce `Parameter` builder
- test channel modifiers

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68632e1cc73c8331abfd635b4fb5a44c